### PR TITLE
bugfix/distributed-runners

### DIFF
--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -100,7 +100,7 @@ class All:
                 # Create or get log dir
                 # Do not include ms
                 log_dir_name = datetime.now().isoformat().split(".")[0]
-                log_dir = Path(f"~/.dask_logs/mti_nma/{log_dir_name}")
+                log_dir = Path(f"~/.dask_logs/mti_nma/{log_dir_name}").expanduser()
                 # Log dir settings
                 log_dir.mkdir(parents=True)
 

--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -222,8 +222,8 @@ class All:
             flow.run(executor=exe)
 
             # If nucleus and cell membrane were anlyzed, draw comparison plot
-            if "Nuc" and "Cell" in structs:
-                draw_whist()
+            # if "Nuc" and "Cell" in structs:
+            #     draw_whist()
 
         # Catch any error and kill the remote dask cluster
         except Exception as err:

--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -117,8 +117,8 @@ class All:
                 )
                 log.info("Created SLURMCluster")
 
-                # Scale workers
-                cluster.scale_up(40)
+                # Set adaptive worker settings
+                cluster.adapt(minimum_jobs=1, maximum_jobs=40)
 
                 # Use the port from the created connector to set executor address
                 distributed_executor_address = cluster.scheduler_address

--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -95,6 +95,7 @@ class All:
         if debug:
             exe = LocalExecutor()
             distributed_executor_address = None
+            log.info(f"Debug flagged. Will use threads instead of Dask.")
         else:
             if distributed:
                 # Create or get log dir

--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -105,6 +105,7 @@ class All:
                 log_dir.mkdir(parents=True)
 
                 # Create cluster
+                log.info("Creating SLURMCluster")
                 cluster = SLURMCluster(
                     cores=2,
                     memory="24GB",
@@ -113,6 +114,7 @@ class All:
                     local_directory=str(log_dir),
                     log_directory=str(log_dir)
                 )
+                log.info("Created SLURMCluster")
 
                 # Scale workers
                 cluster.adapt(minimum_jobs=1, maximum_jobs=40)
@@ -124,7 +126,9 @@ class All:
                 log.info(f"Dask dashboard available at: {cluster.dashboard_link}")
             else:
                 # Create local cluster
+                log.info("Creating LocalCluster")
                 cluster = LocalCluster()
+                log.info("Created LocalCluster")
 
                 # Set distributed_executor_address
                 distributed_executor_address = cluster.scheduler_address

--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -117,7 +117,7 @@ class All:
                 log.info("Created SLURMCluster")
 
                 # Scale workers
-                cluster.adapt(minimum_jobs=1, maximum_jobs=40)
+                cluster.scale_up(40)
 
                 # Use the port from the created connector to set executor address
                 distributed_executor_address = cluster.scheduler_address

--- a/mti_nma/steps/avgshape_cell/avgshape_cell.py
+++ b/mti_nma/steps/avgshape_cell/avgshape_cell.py
@@ -3,9 +3,11 @@
 
 import logging
 from typing import List
-from ..shparam_cell import ShparamCell
+
+from datastep import Step, log_run_params
+
 from ...utils.avgshape_utils import Avgshape
-from datastep import log_run_params
+from ..shparam_cell import ShparamCell
 
 ###############################################################################
 
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class AvgshapeCell(Avgshape):
+class AvgshapeCell(Step, Avgshape):
     def __init__(
         self,
         direct_upstream_tasks: List["Step"] = [ShparamCell],

--- a/mti_nma/steps/avgshape_nuc/avgshape_nuc.py
+++ b/mti_nma/steps/avgshape_nuc/avgshape_nuc.py
@@ -3,9 +3,11 @@
 
 import logging
 from typing import List
-from ..shparam_nuc import ShparamNuc
+
+from datastep import Step, log_run_params
+
 from ...utils.avgshape_utils import Avgshape
-from datastep import log_run_params
+from ..shparam_nuc import ShparamNuc
 
 ###############################################################################
 
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class AvgshapeNuc(Avgshape):
+class AvgshapeNuc(Step, Avgshape):
     def __init__(
         self,
         direct_upstream_tasks: List["Step"] = [ShparamNuc],

--- a/mti_nma/steps/nma_cell/nma_cell.py
+++ b/mti_nma/steps/nma_cell/nma_cell.py
@@ -3,9 +3,11 @@
 
 import logging
 from typing import List
-from ..avgshape_cell import AvgshapeCell
+
+from datastep import Step, log_run_params
+
 from ...utils.nma_utils import Nma
-from datastep import log_run_params
+from ..avgshape_cell import AvgshapeCell
 
 ###############################################################################
 
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class NmaCell(Nma):
+class NmaCell(Step, Nma):
     def __init__(
         self,
         direct_upstream_tasks: List["Step"] = [AvgshapeCell],

--- a/mti_nma/steps/nma_nuc/nma_nuc.py
+++ b/mti_nma/steps/nma_nuc/nma_nuc.py
@@ -3,9 +3,11 @@
 
 import logging
 from typing import List
-from ..avgshape_nuc import AvgshapeNuc
+
+from datastep import Step, log_run_params
+
 from ...utils.nma_utils import Nma
-from datastep import log_run_params
+from ..avgshape_nuc import AvgshapeNuc
 
 ###############################################################################
 
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class NmaNuc(Nma):
+class NmaNuc(Step, Nma):
     def __init__(
         self,
         direct_upstream_tasks: List["Step"] = [AvgshapeNuc],

--- a/mti_nma/steps/shparam_cell/shparam_cell.py
+++ b/mti_nma/steps/shparam_cell/shparam_cell.py
@@ -3,9 +3,11 @@
 
 import logging
 from typing import List, Optional
-from ..single_cell import SingleCell
+
+from datastep import Step, log_run_params
+
 from ...utils.shparam_utils import Shparam
-from datastep import log_run_params
+from ..single_cell import SingleCell
 
 ###############################################################################
 
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class ShparamCell(Shparam):
+class ShparamCell(Step, Shparam):
     def __init__(
         self,
         direct_upstream_tasks: Optional[List["Step"]] = [SingleCell]

--- a/mti_nma/steps/shparam_nuc/shparam_nuc.py
+++ b/mti_nma/steps/shparam_nuc/shparam_nuc.py
@@ -3,9 +3,11 @@
 
 import logging
 from typing import List, Optional
-from ..single_nuc import SingleNuc
+
+from datastep import Step, log_run_params
+
 from ...utils.shparam_utils import Shparam
-from datastep import log_run_params
+from ..single_nuc import SingleNuc
 
 ###############################################################################
 
@@ -14,7 +16,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class ShparamNuc(Shparam):
+class ShparamNuc(Step, Shparam):
     def __init__(
         self,
         direct_upstream_tasks: Optional[List["Step"]] = [SingleNuc]

--- a/mti_nma/steps/single_cell/single_cell.py
+++ b/mti_nma/steps/single_cell/single_cell.py
@@ -2,8 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import logging
+
+from datastep import Step, log_run_params
+
 from ...utils.singlestruct_utils import SingleStruct
-from datastep import log_run_params
 
 ###############################################################################
 
@@ -12,7 +14,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class SingleCell(SingleStruct):
+class SingleCell(Step, SingleStruct):
 
     @log_run_params
     def run(self, **kwargs):

--- a/mti_nma/steps/single_nuc/single_nuc.py
+++ b/mti_nma/steps/single_nuc/single_nuc.py
@@ -2,8 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import logging
+
+from datastep import Step, log_run_params
+
 from ...utils.singlestruct_utils import SingleStruct
-from datastep import log_run_params
 
 ###############################################################################
 
@@ -12,7 +14,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class SingleNuc(SingleStruct):
+class SingleNuc(Step, SingleStruct):
 
     @log_run_params
     def run(self, **kwargs):

--- a/mti_nma/utils/avgshape_utils.py
+++ b/mti_nma/utils/avgshape_utils.py
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from aicsshparam import shtools
-from datastep import Step, log_run_params
 from stl import mesh
 
 ###############################################################################
@@ -15,7 +14,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class Avgshape(Step):
+class Avgshape:
     def __init__(
         self,
         direct_upstream_tasks,
@@ -27,7 +26,6 @@ class Avgshape(Step):
             filepath_columns=filepath_columns
         )
 
-    @log_run_params
     def run_avgshape_step(self, sh_df=None, struct="Nuc", **kwargs):
         """
         This step uses the amplitudes of the spherical harmonic components

--- a/mti_nma/utils/dask_utils.py
+++ b/mti_nma/utils/dask_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 from concurrent.futures import Future as ThreadFuture
 from concurrent.futures import ThreadPoolExecutor as ThreadClient
 from typing import Any, Iterable, Optional, Union
@@ -10,9 +11,15 @@ from distributed import Future as DaskFuture
 
 #######################################################################################
 
+log = logging.getLogger(__name__)
+
+###############################################################################
+
 
 class DistributedHandler:
     def __init__(self, address: Optional[str] = None):
+        log.info(f"Spawned DistributedHandler with address: {address}")
+
         # Create client based off address existance
         if address is None:
             self._client = ThreadClient()

--- a/mti_nma/utils/nma_utils.py
+++ b/mti_nma/utils/nma_utils.py
@@ -1,16 +1,16 @@
-import numpy as np
 import itertools
 import logging
 import subprocess
 from pathlib import Path
-import matplotlib
-import matplotlib.pyplot as plt
-import seaborn as sb
 from sys import platform
 from typing import Optional
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
+import seaborn as sb
 import vtk
-from datastep import Step, log_run_params
 
 from . import dask_utils
 
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 
-class Nma(Step):
+class Nma:
     """
     This step is used to run normal mode analysis on a given mesh by:
     1) Extracting vertices and faces from vtk polydata mesh
@@ -48,7 +48,6 @@ class Nma(Step):
             filepath_columns=filepath_columns
         )
 
-    @log_run_params
     def run_nma_step(
         self,
         mode_list=list(range(6)),
@@ -300,12 +299,12 @@ def get_eigvec_mags(v):
     ----------
     v: Numpy 2D array
         Each array in this array gives the displacement vector for a vertex in the mesh
-        The array giving the eigenvectors associated with eigenvalue w[i] are in v[:. i] 
+        The array giving the eigenvectors associated with eigenvalue w[i] are in v[:. i]
     Returns
     -------
     vmags: 2D Numpy array
         Each array in this array gives the relative displacement magntiude for a vertex
-        in the mesh. The array giving the magnitudes associated with eigenvalue w[i] 
+        in the mesh. The array giving the magnitudes associated with eigenvalue w[i]
         are in vmags[:. i]
     """
 
@@ -330,7 +329,7 @@ def get_vtk_verts_faces(polydata):
     Parameters
     ----------
     polydata: VTK polydata object
-        Mesh extracted from .vtk file 
+        Mesh extracted from .vtk file
     Returns
     -------
     mesh_verts: Numpy 2D array
@@ -351,7 +350,7 @@ def get_vtk_verts_faces(polydata):
         i : int
             Index of the face for which we want to get the vertex points
         polydata: VTK polydata object
-            Mesh extracted from .vtk file 
+            Mesh extracted from .vtk file
         Returns
         -------
         mesh_verts: Numpy 1D array

--- a/mti_nma/utils/shparam_utils.py
+++ b/mti_nma/utils/shparam_utils.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import Any, Dict, NamedTuple, Optional
 
 import pandas as pd
-from aicsimageio import AICSImage
 from aicsshparam import shparam, shtools
-from datastep import Step, log_run_params
+
+from aicsimageio import AICSImage
 
 from . import dask_utils
 
@@ -26,7 +26,7 @@ class CellProcessResult(NamedTuple):
 ###############################################################################
 
 
-class Shparam(Step):
+class Shparam:
     def __init__(
         self,
         direct_upstream_tasks,
@@ -108,7 +108,6 @@ class Shparam(Step):
         log.info(f"Completed processing for cell: {cell_id}")
         return CellProcessResult(cell_id, data)
 
-    @log_run_params
     def run_shparam_step(
         self,
         sc_df=None,

--- a/mti_nma/utils/singlestruct_utils.py
+++ b/mti_nma/utils/singlestruct_utils.py
@@ -45,6 +45,7 @@ class SingleStruct:
             filepath_columns=filepath_columns
         )
 
+    @staticmethod
     def _process_fov(
         fov_id: int,
         fov_details: pd.Series,

--- a/mti_nma/utils/singlestruct_utils.py
+++ b/mti_nma/utils/singlestruct_utils.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
+import uuid
+from pathlib import Path
 from sys import platform
+from typing import Any, Dict, NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
 from lkaccess import LabKey, contexts
 from skimage import transform as sktrans
 
-import logging
-import uuid
-from pathlib import Path
-from typing import Any, Dict, NamedTuple, Optional
-
 from aicsimageio import AICSImage, writers
-from datastep import Step, log_run_params
+
 from . import dask_utils
 
 ###############################################################################
@@ -32,7 +31,7 @@ class FOVProcessResult(NamedTuple):
 ###############################################################################
 
 
-class SingleStruct(Step):
+class SingleStruct:
 
     def __init__(
         self,
@@ -46,7 +45,6 @@ class SingleStruct(Step):
             filepath_columns=filepath_columns
         )
 
-    @staticmethod
     def _process_fov(
         fov_id: int,
         fov_details: pd.Series,
@@ -124,7 +122,6 @@ class SingleStruct(Step):
         log.info(f"Completed processing for FOV: {fov_id}")
         return result
 
-    @log_run_params
     def run_singlestruct_step(
         self,
         cell_line_id="AICS-13",

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ interactive_requirements = [
 ]
 
 requirements = [
-    "aicsimageio",
-    "aicsshparam",
+    "aicsimageio>=3.1.2",
+    "aicsshparam>=0.0.7",
     "bokeh",
     "datastep>=0.1.5",
     "dask[bag]",


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.

It got it working after I did two things, I am not sure which one did it.
* Set all steps to inherit from `Step` and their associated utility class. I think have a step inherit from step may have been causing some weird behavior, and at the very least it was spawning additional directories for all the utility steps. The new versions look like `class MyStepName(Step, SharedUtilityClass)`.
* Force reinstalled all packages after making dependencies changes, `pip install --no-cache-dir --force-reinstall -e .`

Minor changes:
* Added `expanduser` to log dir path because it was created a directory called `"~"` without it.
* Added log statements wrapping the cluster and debug setups for easier tracking in the terminal as to which runner was chosen.
* Set dependency version pins for `aicsshparam` and `aicsimageio`.
* Commented out the `draw_whist` function as I encountered some odd errors where if the pipeline failed but that function ran I would get a `FileNotFoundError`, because well the pipeline had failed to run, but tracking that down was a bit complicated.... I would add that function to inside the `Flow` and as a `Step` so that it is properly triggered by upstream success / failure.

I ran the pipeline with this branch on a CPU node with the command:
`mti_nma all run --distributed True --nsamples 40 --lmax 10 --structs Nuc,Cell --path_blender /allen/aics/modeling/jacksonb/applications/blender-2.82-linux64/blender`

Results are stored at: `/allen/aics/modeling/jacksonb/projects/mti_nma/local_staging/`

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
