### PR TITLE
bugfix/slurm-cluster-config

### DIFF
--- a/mti_nma/bin/all.py
+++ b/mti_nma/bin/all.py
@@ -114,8 +114,8 @@ class All:
                 # Create cluster
                 log.info("Creating SLURMCluster")
                 cluster = SLURMCluster(
-                    cores=2,
-                    memory="24GB",
+                    cores=1,
+                    memory="12GB",
                     queue="aics_cpu_general",
                     walltime="10:00:00",
                     local_directory=str(log_dir),
@@ -124,7 +124,7 @@ class All:
                 log.info("Created SLURMCluster")
 
                 # Scale workers
-                cluster.scale_up(30)
+                cluster.adapt(minimum_jobs=30, maximum_jobs=100)
 
                 # Use the port from the created connector to set executor address
                 distributed_executor_address = cluster.scheduler_address


### PR DESCRIPTION
I _think_ the issue was that you were requesting too many _large_ resource workers. Additionally, as I get better at understanding the constraints of distributed workers I learn that if more than 1 core is on a worker it tries to multiprocess, on top of each worker. This is usually what causes memory issues.

So dropping this to 1 core and 12 GB per worker and upping the number of maximum jobs to 100 means that it churned through:

`mti_nma all run --nsamples 50 --lmax 10`

in about 10 minutes :tada: 